### PR TITLE
Craft 5 compatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/collections": "^8.23|^9.1|^10.0",
         "pestphp/pest": "^2.26",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
-        "craftcms/cms": "^4.5|^5.0.0-beta.1",
+        "craftcms/cms": "^5.0.0-beta.1",
         "illuminate/support": "^9.52|^10.42.0"
     },
     "autoload": {
@@ -54,7 +54,7 @@
     "prefer-stable": true,
     "require-dev": {
         "craftcms/phpstan": "dev-main",
-        "craftcms/craft": "^2.0",
+        "craftcms/craft": "^5.0.0-alpha.1",
         "symfony/var-dumper": "^5.0|^6.0",
         "laravel/pint": "^1.13"
     }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "pestphp/pest": "^2.26",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
         "craftcms/cms": "^4.5|^5.0.0-beta.1",
-        "illuminate/support": "^9.52"
+        "illuminate/support": "^9.52|^10.42.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "composer/composer": "^2.7.0",
         "fakerphp/faker": "^1.16",
         "mockery/mockery": "^1.5",
         "symfony/css-selector": "^5.3|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/collections": "^8.23|^9.1|^10.0",
         "pestphp/pest": "^2.26",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
-        "craftcms/cms": "^4.5",
+        "craftcms/cms": "^4.5|^5.0.0-beta.1",
         "illuminate/support": "^9.52"
     },
     "autoload": {


### PR DESCRIPTION
I initially though that adding support for Craft 5 would just be a matter of updating composer requirements, but it turns out that the content table changes need addressing.

Specifically the `RenderCompiledClasses::handle()` method:
https://github.com/markhuot/craft-pest-core/blob/23e7ecbea61a7bf43539f23de7235ce3ac70c18b/src/actions/RenderCompiledClasses.php#L11-L28