### PR TITLE
Craft 5 compatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/collections": "^8.23|^9.1|^10.0",
         "pestphp/pest": "^2.26",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
-        "craftcms/cms": "^4.5|^5.0.0-beta.1",
+        "craftcms/cms": "^5.0.0-beta.1",
         "illuminate/support": "^9.52|^10.42.0"
     },
     "autoload": {
@@ -54,7 +54,7 @@
     "prefer-stable": true,
     "require-dev": {
         "craftcms/phpstan": "dev-main",
-        "craftcms/craft": "^2.0",
+        "craftcms/craft": "^5.0.0-alpha.1",
         "symfony/var-dumper": "^5.0|^6.0",
         "laravel/pint": "^1.13"
     }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "pestphp/pest": "^2.26",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
         "craftcms/cms": "^4.5|^5.0.0-beta.1",
-        "illuminate/support": "^9.52"
+        "illuminate/support": "^9.52|^10.42.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "composer/composer": "^2.7.0",
         "fakerphp/faker": "^1.16",
         "mockery/mockery": "^1.5",
         "symfony/css-selector": "^5.3|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/collections": "^8.23|^9.1|^10.0",
         "pestphp/pest": "^2.26",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
-        "craftcms/cms": "^4.5",
+        "craftcms/cms": "^4.5|^5.0.0-beta.1",
         "illuminate/support": "^9.52"
     },
     "autoload": {

--- a/src/actions/RenderCompiledClasses.php
+++ b/src/actions/RenderCompiledClasses.php
@@ -10,19 +10,20 @@ class RenderCompiledClasses
 {
     public function handle($forceRecreate = false)
     {
-        $contentService = \Craft::$app->getContent();
-        $originalContentTable = $contentService->contentTable;
-        $originalFieldColumnPrefix = $contentService->fieldColumnPrefix;
-        $originalFieldContext = $contentService->fieldContext;
-        $contentService->contentTable = Table::CONTENT;
-        $contentService->fieldColumnPrefix = 'field_';
-        $contentService->fieldContext = 'global';
+        // TODO: review what this is actually doing
+        // $contentService = \Craft::$app->getContent();
+        // $originalContentTable = $contentService->contentTable;
+        // $originalFieldColumnPrefix = $contentService->fieldColumnPrefix;
+        // $originalFieldContext = $contentService->fieldContext;
+        // $contentService->contentTable = Table::CONTENT;
+        // $contentService->fieldColumnPrefix = 'field_';
+        // $contentService->fieldContext = 'global';
 
         $this->render($forceRecreate);
 
-        $contentService->contentTable = $originalContentTable;
-        $contentService->fieldColumnPrefix = $originalFieldColumnPrefix;
-        $contentService->fieldContext = $originalFieldContext;
+        // $contentService->contentTable = $originalContentTable;
+        // $contentService->fieldColumnPrefix = $originalFieldColumnPrefix;
+        // $contentService->fieldContext = $originalFieldContext;
 
         return true;
     }

--- a/src/factories/Element.php
+++ b/src/factories/Element.php
@@ -89,28 +89,27 @@ abstract class Element extends Factory
     }
 
     /**
-     * @param  array  $attributes
-     * @param  \craft\base\Element  $element
+     * @param array $attributes
+     * @param \craft\base\Element $element
      */
     protected function setAttributes($attributes, $element)
     {
         // Set the element native fields first (ignoring any custom fields)
         foreach ($attributes as $key => $value) {
             $fieldLayout = $element->getFieldLayout();
-            if (! $fieldLayout || ! $fieldLayout->getFieldByHandle($key)) {
+            if (!$fieldLayout || !$fieldLayout->getFieldByHandle($key)) {
                 $element->{$key} = $value;
                 unset($attributes[$key]);
             }
         }
 
-        // No need to progress further if the element doesn't support content or has no field layout
-        if (! $element::hasContent() || ! $element->getFieldLayout()) {
+        // No need to progress further if the element has no field layout
+        if (!$element->getFieldLayout()) {
             return $element;
         }
 
         // render out any nested factories while setting the custom field values
         foreach ($attributes as $key => &$value) {
-
             // Unfortunately $element->fieldLayout->getFields() does not look in all the
             // tabs for fields (in 3.7, at least), so we need to manually get all the tabs,
             // then get the fields from each tab and then search over the cumulative list
@@ -126,15 +125,15 @@ abstract class Element extends Factory
             $field = $element->fieldLayout->getFieldByHandle($key);
 
             if (empty($field)) {
-                throw new \Exception('Could not find field with handle `'.$key.'` on `'.get_class($element).'`');
+                throw new \Exception('Could not find field with handle `' . $key . '` on `' . get_class($element) . '`');
             }
 
             if (is_subclass_of($field, BaseRelationField::class)) {
-                $value = $this->resolveFactories(array_wrap($value))->map(function ($element) {
+                $value = $this->resolveFactories(array_wrap($value))->map(function($element) {
                     if (is_numeric($element)) {
                         return $element;
                     }
-                    if (is_object($element) && ! empty($element->id)) {
+                    if (is_object($element) && !empty($element->id)) {
                         return $element->id;
                     }
 
@@ -144,8 +143,8 @@ abstract class Element extends Factory
 
             if (is_a($field, Matrix::class)) {
                 $value = $this->resolveFactories(array_wrap($value))
-                    ->mapWithKeys(function ($item, $index) {
-                        return ['new'.($index + 1) => $item];
+                    ->mapWithKeys(function($item, $index) {
+                        return ['new' . ($index + 1) => $item];
                     })->toArray();
             }
 

--- a/src/factories/Entry.php
+++ b/src/factories/Entry.php
@@ -55,7 +55,6 @@ class Entry extends Element
      */
     public function type($handle)
     {
-
     }
 
     /**
@@ -92,7 +91,7 @@ class Entry extends Element
     public function setDateField($key, $value)
     {
         if (is_numeric($value)) {
-            $value = new \DateTime('@'.$value);
+            $value = new \DateTime('@' . $value);
         } elseif (is_string($value)) {
             $value = new \DateTime($value);
         }
@@ -112,7 +111,7 @@ class Entry extends Element
             $user = \Craft::$app->users->getUserByUsernameOrEmail($user);
         }
 
-        if (! is_a($user, \craft\elements\User::class)) {
+        if (!is_a($user, \craft\elements\User::class)) {
             throw new \Exception('You must pass a User object or a valid user ID or username to the `author()` method.');
         }
 
@@ -131,14 +130,14 @@ class Entry extends Element
         if (is_a($this->sectionIdentifier, \craft\models\Section::class)) {
             $section = $this->sectionIdentifier;
         } elseif (is_numeric($this->sectionIdentifier)) {
-            $section = \Craft::$app->sections->getSectionById($this->sectionIdentifier);
+            $section = \Craft::$app->entries->getSectionById($this->sectionIdentifier);
         } elseif (is_string($this->sectionIdentifier)) {
-            $section = \Craft::$app->sections->getSectionByHandle($this->sectionIdentifier);
+            $section = \Craft::$app->entries->getSectionByHandle($this->sectionIdentifier);
         } else {
             $reflector = new \ReflectionClass($this);
             $className = $reflector->getShortName();
             $sectionHandle = lcfirst($className);
-            $section = \Craft::$app->sections->getSectionByHandle($sectionHandle);
+            $section = \Craft::$app->entries->getSectionByHandle($sectionHandle);
         }
 
         if (empty($section)) {
@@ -158,8 +157,8 @@ class Entry extends Element
         $reflector = new \ReflectionClass($this);
         $className = $reflector->getShortName();
         $typeHandle = lcfirst($className);
-        $section = \Craft::$app->sections->getSectionById($sectionid);
-        $matches = array_filter($section->entryTypes, fn ($e) => $e->handle === $typeHandle);
+        $section = \Craft::$app->entries->getSectionById($sectionid);
+        $matches = array_filter($section->entryTypes, fn($e) => $e->handle === $typeHandle);
         if (count($matches) === 0) {
             $matches = $section->entryTypes;
         }

--- a/src/factories/Section.php
+++ b/src/factories/Section.php
@@ -4,7 +4,6 @@ namespace markhuot\craftpest\factories;
 
 use craft\helpers\StringHelper;
 use craft\models\Section_SiteSettings;
-use Faker\Factory as Faker;
 use Illuminate\Support\Collection;
 
 /**
@@ -80,14 +79,14 @@ class Section extends Factory
 
     public function inferences(array $definition = [])
     {
-        if (! empty($definition['name']) && empty($definition['handle'])) {
+        if (!empty($definition['name']) && empty($definition['handle'])) {
             $definition['handle'] = StringHelper::toCamelCase($definition['name']);
         }
 
         $name = $definition['name'];
         $handle = $definition['handle'];
         $definition['siteSettings'] = collect(\Craft::$app->sites->getAllSites())
-            ->mapWithkeys(function ($site) use ($name, $handle) {
+            ->mapWithkeys(function($site) use ($name, $handle) {
                 $settings = new Section_SiteSettings();
                 $settings->siteId = $site->id;
                 $settings->hasUrls = $this->hasUrls;
@@ -107,11 +106,11 @@ class Section extends Factory
     /**
      * Persist the entry to local
      *
-     * @param  \craft\models\Section  $element
+     * @param \craft\models\Section $element
      */
     public function store($element)
     {
-        $result = \Craft::$app->sections->saveSection($element);
+        $result = \Craft::$app->entries->saveSection($element);
         $this->storeFields($element->entryTypes[0]->fieldLayout);
 
         return $result;

--- a/stubs/compiled_classes/FactoryFields.twig
+++ b/stubs/compiled_classes/FactoryFields.twig
@@ -4,11 +4,11 @@ namespace markhuot\craftpest\storage;
 
 /**
  {% for field in fields %}
- * @method $this {{ field.handle }}({{ field.factoryTypeHint|default('mixed $value') }}) Sets the {{ field.name }} custom field {{ field.valueType }}
+ * @method $this {{ field.handle }}({{ field.factoryTypeHint|default('mixed $value') }}) Sets the {{ field.name }} custom field {{ field.phpType }}
  {% endfor %}
  *
  {% for field in fields %}
- {% if 'craft\\elements\\db\\MatrixBlockQuery' in field.valueType %}
+ {% if 'craft\\elements\\db\\MatrixBlockQuery' in field.phpType %}
  {% for blockType in field.blockTypes %}
  {% if loop.first %}
  * @method $this addBlockTo{{ field.handle|ucfirst }}({{ blockType.fieldLayout.getCustomFieldElements()|map(f => f.getField().factoryTypeHint|default('mixed $value'))|join(', ') }})

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,67 +2,67 @@
 
 use craft\fields\Entries;
 
-it('can create singles', function () {
+it('can create singles', function() {
     $section = \markhuot\craftpest\factories\Section::factory()
         ->type('single')
         ->create();
 
-    expect(Craft::$app->sections->getSectionByHandle($section->handle)->type)->toBe('single');
+    expect(Craft::$app->entries->getSectionByHandle($section->handle)->type)->toBe('single');
 });
 
-it('can create channels', function () {
+it('can create channels', function() {
     $section = \markhuot\craftpest\factories\Section::factory()
         ->type('channel')
         ->create();
 
-    expect(Craft::$app->sections->getSectionByHandle($section->handle)->type)->toBe('channel');
+    expect(Craft::$app->entries->getSectionByHandle($section->handle)->type)->toBe('channel');
 });
 
-it('can create structures', function () {
+it('can create structures', function() {
     $section = \markhuot\craftpest\factories\Section::factory()
         ->type('structure')
         ->create();
 
-    expect(Craft::$app->sections->getSectionByHandle($section->handle)->type)->toBe('structure');
+    expect(Craft::$app->entries->getSectionByHandle($section->handle)->type)->toBe('structure');
 });
 
-it('can set hasUrls of the section', function () {
+it('can set hasUrls of the section', function() {
     $section = \markhuot\craftpest\factories\Section::factory()
         ->hasUrls(false)
         ->create();
 
     $siteId = \Craft::$app->sites->getCurrentSite()->id;
-    expect(Craft::$app->sections->getSectionByHandle($section->handle)->siteSettings[$siteId]->hasUrls)->toBe(false);
+    expect(Craft::$app->entries->getSectionByHandle($section->handle)->siteSettings[$siteId]->hasUrls)->toBe(false);
 });
 
-it('can set uriFormat of the section', function () {
+it('can set uriFormat of the section', function() {
     $section = \markhuot\craftpest\factories\Section::factory()
         ->uriFormat('{sluggy}')
         ->create();
 
     $siteId = \Craft::$app->sites->getCurrentSite()->id;
-    expect(Craft::$app->sections->getSectionByHandle($section->handle)->siteSettings[$siteId]->uriFormat)->toBe('{sluggy}');
+    expect(Craft::$app->entries->getSectionByHandle($section->handle)->siteSettings[$siteId]->uriFormat)->toBe('{sluggy}');
 });
 
-it('can set enabledByDefault of the section', function () {
+it('can set enabledByDefault of the section', function() {
     $section = \markhuot\craftpest\factories\Section::factory()
         ->enabledByDefault(false)
         ->create();
 
     $siteId = \Craft::$app->sites->getCurrentSite()->id;
-    expect(Craft::$app->sections->getSectionByHandle($section->handle)->siteSettings[$siteId]->enabledByDefault)->toBe(false);
+    expect(Craft::$app->entries->getSectionByHandle($section->handle)->siteSettings[$siteId]->enabledByDefault)->toBe(false);
 });
 
-it('can set template of the section', function () {
+it('can set template of the section', function() {
     $section = \markhuot\craftpest\factories\Section::factory()
         ->template('_foo/{handle}/bar')
         ->create();
 
     $siteId = \Craft::$app->sites->getCurrentSite()->id;
-    expect(Craft::$app->sections->getSectionByHandle($section->handle)->siteSettings[$siteId]->template)->toBe(implode('/', ['_foo', $section->handle, 'bar']));
+    expect(Craft::$app->entries->getSectionByHandle($section->handle)->siteSettings[$siteId]->template)->toBe(implode('/', ['_foo', $section->handle, 'bar']));
 });
 
-it('can create entries with section id, handle, and object', function () {
+it('can create entries with section id, handle, and object', function() {
     $section = \markhuot\craftpest\factories\Section::factory()->create();
 
     $setById = \markhuot\craftpest\factories\Entry::factory()->section($section->id)->create();
@@ -75,7 +75,7 @@ it('can create entries with section id, handle, and object', function () {
     expect($setByObject->errors)->toBeEmpty();
 });
 
-it('can fill an entries field', function () {
+it('can fill an entries field', function() {
     $entry = \markhuot\craftpest\factories\Entry::factory()
         ->section('posts')
         ->entriesField(
@@ -86,7 +86,7 @@ it('can fill an entries field', function () {
     expect($entry->entriesField->all())->toHaveCount(1);
 });
 
-it('can place fields in groups', function () {
+it('can place fields in groups', function() {
     $field = \markhuot\craftpest\factories\Field::factory()
         ->type(Entries::class)
         ->group('Common')
@@ -95,7 +95,7 @@ it('can place fields in groups', function () {
     expect($field->getGroup()->name)->toBe('Common');
 });
 
-it('can create fields', function () {
+it('can create fields', function() {
     $field = \markhuot\craftpest\factories\Field::factory()
         ->type(Entries::class)
         ->create();
@@ -142,8 +142,8 @@ it('can create fields', function () {
     }
 });
 
-dataset('entries field', function () {
-    yield function () {
+dataset('entries field', function() {
+    yield function() {
         $field = \markhuot\craftpest\factories\Field::factory()
             ->type(Entries::class)
             ->create();
@@ -159,7 +159,7 @@ dataset('entries field', function () {
     };
 });
 
-it('automatically resolves factories via method', function ($props) {
+it('automatically resolves factories via method', function($props) {
     [$factory, $section, $field] = $props;
 
     $entry = $factory->{$field->handle}(
@@ -170,7 +170,7 @@ it('automatically resolves factories via method', function ($props) {
     expect(\craft\elements\Entry::find()->id($entry->id)->one()->{$field->handle}->count())->toEqual(2);
 })->with('entries field');
 
-it('automatically resolves factories with ->count()', function ($props) {
+it('automatically resolves factories with ->count()', function($props) {
     [$factory, $section, $field] = $props;
 
     $entry = $factory->{$field->handle}(
@@ -180,7 +180,7 @@ it('automatically resolves factories with ->count()', function ($props) {
     expect(\craft\elements\Entry::find()->id($entry->id)->one()->{$field->handle}->count())->toEqual(5);
 })->with('entries field');
 
-it('automatically resolves factories via ->create() definition', function ($props) {
+it('automatically resolves factories via ->create() definition', function($props) {
     [$factory, $section, $field] = $props;
 
     $entry = $factory->create([
@@ -190,7 +190,7 @@ it('automatically resolves factories via ->create() definition', function ($prop
     expect(\craft\elements\Entry::find()->id($entry->id)->one()->{$field->handle}->count())->toEqual(5);
 })->with('entries field');
 
-it('takes an array of entries', function ($props) {
+it('takes an array of entries', function($props) {
     [$factory, $section, $field] = $props;
 
     $children = \markhuot\craftpest\factories\Entry::factory()->section($section->handle)->count(3)->create();
@@ -206,7 +206,7 @@ it('takes an array of entries', function ($props) {
     expect(\craft\elements\Entry::find()->id($entry->id)->one()->{$field->handle}->ids())->toEqualCanonicalizing($children->pluck('id')->toArray());
 })->with('entries field');
 
-it('allows you to use ->set()` on a factory', function () {
+it('allows you to use ->set()` on a factory', function() {
     $section = \markhuot\craftpest\factories\Section::factory()->create();
     $entry = \markhuot\craftpest\factories\Entry::factory()->section($section->handle)->set('title', 'foo')->create();
 


### PR DESCRIPTION
I initially though that adding support for Craft 5 would just be a matter of updating composer requirements, but it turns out that the content table changes need addressing.

Specifically, the `RenderCompiledClasses::handle()` method needs reviewing. I’ve commented out most of this method for the meantime, as I’m not sure what its purpose is.
https://github.com/bencroker/craft-pest-core/blob/6659ef007419d5b96bb0f2f5fecdfc6f1df598e0/src/actions/RenderCompiledClasses.php#L11-L29

As it is now, simple tests are running with Craft 5.0.0-beta.1, but this is a WIP!