### PR TITLE
Add `illuminate/support:^11.0` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "pestphp/pest": "^2.26",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
         "craftcms/cms": "^4.5|^5.0.0-beta.1",
-        "illuminate/support": "^9.52|^10.0|^11.0",
+        "illuminate/support": "^9.52|^10.0|^v11.0",
         "composer/composer": "^2.7",
         "composer/semver": "^3.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "pestphp/pest": "^2.26",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
         "craftcms/cms": "^4.5|^5.0.0-beta.1",
-        "illuminate/support": "^9.52|^10.0",
+        "illuminate/support": "^9.52|^10.0|^11.0",
         "composer/composer": "^2.7",
         "composer/semver": "^3.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "pestphp/pest": "^2.26",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
         "craftcms/cms": "^4.5|^5.0.0-beta.1",
-        "illuminate/support": "^9.52|^10.0|^v11.0",
+        "illuminate/support": "^9.52|^10.0|^11.0",
         "composer/composer": "^2.7",
         "composer/semver": "^3.4"
     },


### PR DESCRIPTION
Adds support for `illuminate/support` version `^11.0`, which is required for compatibility with Feed Me’s requirements.