### PR TITLE
Fixes failing attribute defined test

### DIFF
--- a/stubs/compiled_classes/FactoryFields.twig
+++ b/stubs/compiled_classes/FactoryFields.twig
@@ -3,10 +3,11 @@
 namespace markhuot\craftpest\storage;
 
 /**
+ {% set type = '' %}
  {% for field in fields %}
- {% if attribute(field, 'valueType') is defined %}
+ {% if craft.app.version < 5 %}
 {% set type = field.valueType() %}
-{% elseif attribute(field, 'phpType') is defined %}
+{% elseif craft.app.version > 5 %}
 {% set type = field.phpType() %}
 {% else %}
 {% set type = 'mixed' %}


### PR DESCRIPTION
Running on Craft 5 results in the error, `Calling unknown method: craft\fields\Dropdown::valueType()`.

The code in question is failing because the attribute `is defined` test on objects that extend the `Component` class (or any class that implements `__call()`) always returns `true`.
https://github.com/markhuot/craft-pest-core/blob/cd7edd65aff8068f5de21e59d5dd9fc31c98671e/stubs/compiled_classes/FactoryFields.twig#L7-L10

This is a [known issue](https://github.com/craftcms/cms/issues/14934).

This PR is a simple workaround that performs the check based on the Craft versions.

```twig
 {% for field in fields %}
 {% if craft.app.version < 5 %}
{% set type = field.valueType() %}
{% elseif craft.app.version > 5 and (attribute(field, 'phpType') is defined) %}
```

There’s probably a more elegant way to check for Craft version, I’ll leave that up to you.

I also found that `type` needs a default value since it may not be set when tested against https://github.com/markhuot/craft-pest-core/blob/cd7edd65aff8068f5de21e59d5dd9fc31c98671e/stubs/compiled_classes/FactoryFields.twig#L18

Resulting in this working code.

```twig
 {% set type = '' %}
 {% for field in fields %}
 {% if craft.app.version < 5 %}
{% set type = field.valueType() %}
{% elseif craft.app.version > 5 and (attribute(field, 'phpType') is defined) %}
```