### PR TITLE
Allow Pest 2 OR 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/css-selector": "^5.3|^6.0",
         "symfony/dom-crawler": "^6.0.3",
         "symfony/process": "^5.3|^6.0",
-        "pestphp/pest": "^3.0",
+        "pestphp/pest": "^2.26|^3.0",
         "vlucas/phpdotenv": "^2.4|^3.4|^5.4",
         "craftcms/cms": "^4.5|^5.0.0-beta.1",
         "illuminate/support": "^9.52|^10.0|^11.0",


### PR DESCRIPTION
I’ve so far found that [Pest](https://github.com/pestphp/pest) 3 conflicts with the following plugins/packages.

- `craftcms/commerce`
- `craftcms/commerce-stripe`
- `craftcms/generator`
- `yiisoft/yii2-shell`

This PR allows both Pest 2 and 3 to be used, so that the packages above can also be tested.