### PR TITLE
fix: run app and plugin migrations on update path (#80)

### DIFF
--- a/src/pest/InstallsCraft.php
+++ b/src/pest/InstallsCraft.php
@@ -75,7 +75,16 @@ class InstallsCraft implements HandlesArguments
             $this->logEnd('Craft CMS installed', $start);
         }
 
-        if (Craft::$app->getContentMigrator()->getNewMigrations()) {
+        $migrators = $this->getMigrators();
+        $hasPending = false;
+        foreach ($migrators as $migrator) {
+            if ($migrator->getNewMigrations()) {
+                $hasPending = true;
+                break;
+            }
+        }
+
+        if ($hasPending) {
             $start = $this->logStart('Running migrations...');
             $this->craftMigrateAll();
             $this->logEnd('Migrations complete', $start);
@@ -166,7 +175,30 @@ class InstallsCraft implements HandlesArguments
 
     protected function craftMigrateAll()
     {
-        Craft::$app->getContentMigrator()->up();
+        foreach ($this->getMigrators() as $migrator) {
+            if ($migrator->getNewMigrations()) {
+                $migrator->up();
+            }
+        }
+    }
+
+    /**
+     * Returns the migrators that `php craft migrate/all` would run, in the
+     * same order: Craft core (app), each installed plugin, then content.
+     *
+     * @return array<string, \craft\db\MigrationManager>
+     */
+    protected function getMigrators(): array
+    {
+        $migrators = ['app' => Craft::$app->getMigrator()];
+
+        foreach (Craft::$app->getPlugins()->getAllPlugins() as $plugin) {
+            $migrators["plugin:{$plugin->id}"] = $plugin->getMigrator();
+        }
+
+        $migrators['content'] = Craft::$app->getContentMigrator();
+
+        return $migrators;
     }
 
     protected function craftApplyProjectConfig(): void


### PR DESCRIPTION
## Summary

Fixes #80. `InstallsCraft::install()` only checked and ran the content migrator on the update path, so Craft core and plugin schema migrations silently fell behind on the test database. The next `applyExternalChanges()` then blew up referencing columns that were never added (e.g. `sections.minAuthors` after the 5.10.x core migration).

This mirrors `MigrateController::actionAll()`: collect the app, per-plugin, and content migrators (in that order) and run `up()` on any with pending migrations.

## Changes

- Added `InstallsCraft::getMigrators()` returning `app` + each plugin + `content`, matching the order `php craft migrate/all` uses.
- `install()` now checks all tracks (not just content) when deciding whether to run migrations.
- `craftMigrateAll()` now iterates every migrator with pending work and runs `up()` on each.

## Test plan

- [ ] On a project where the test DB lags behind dev (e.g. Craft bumped to a version with a new core migration), run `vendor/bin/pest` and confirm the test DB is brought up to date before project-config apply.
- [ ] On an already-in-sync test DB, confirm the "Running migrations..." step is skipped (no-op).
- [ ] On a fresh install, confirm the existing `craftInstall()` path still runs (gated by `getIsInstalled`).